### PR TITLE
Feature/gift support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ dist
 
 # project specific .env files
 *development.json
+*production.json
 *test.json
 *docker-compose.yml
 # Build

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY yarn.lock ./
 
 RUN yarn --frozen-lock
 
-RUN yarn build
+# RUN yarn build
 
 COPY ./ ./
 

--- a/src/controller/CustomersController.ts
+++ b/src/controller/CustomersController.ts
@@ -63,9 +63,11 @@ class CustomersController {
       }
 
       // retrieve all pets of customer
+      // todo: optimize on db level
       const pets = await this._petsService.findByOwnerId(customerId);
 
       // filter unique pet types
+      // todo: optimize on db level
       const set = new Set(pets);
       const uniquePets = Array.from(set);
 

--- a/src/controller/CustomersController.ts
+++ b/src/controller/CustomersController.ts
@@ -1,11 +1,13 @@
 import { NextFunction, Request, Response } from "express";
 import { injectable } from "inversify";
 import Service from "../service/customers/CustomersService";
+import PetsService from "../service/pets/PetsService";
+import PurchasesService from "../service/purchases/PurchasesService";
 import ApiError from "../middleware/ApiError";
 
 @injectable()
 class CustomersController {
-  constructor(private readonly _service: Service) {
+  constructor(private readonly _service: Service, private readonly _petsService: PetsService, private readonly _purchasesService: PurchasesService) {
     this.getAll = this.getAll.bind(this);
   }
 

--- a/src/controller/CustomersController.ts
+++ b/src/controller/CustomersController.ts
@@ -38,7 +38,7 @@ class CustomersController {
         });
 
       }
-      // intermediate arrange for customer object prep
+      // convert customer to json
       const customerObj = customer?.$toDatabaseJson();
 
       // check if customer has an applied gift.
@@ -49,11 +49,10 @@ class CustomersController {
         });
       }
 
-      // intermediate arrange for date filter prep
+      // prepare the date for 6 months ago in UTC timezone. knexfile is set to UTC timezone.
       let d = new Date();
       d.setMonth(d.getMonth() - 6);
-      const dateFilter = d.toISOString();
-      console.log(dateFilter);
+      const dateFilter = d.toISOString(); 
 
       // check if customer is eligible for a gift.
       const allPurchases = await this._purchasesService.findByCustomerIdAndDate(customerId, dateFilter);
@@ -68,13 +67,7 @@ class CustomersController {
       }
 
       // retrieve all pets of customer
-      // todo: optimize in db level
-      const pets = await this._petsService.findByOwnerId(customerId);
-
-      // filter unique pet types
-      // todo: optimize in db level
-      const set = new Set(pets);
-      const uniquePets = Array.from(set);
+      const uniquePets = await this._petsService.findDistinctTypesByOwnerId(customerId);
 
       // deduce a random pet gift for customer
       const randomSpecies = uniquePets[Math.floor(Math.random() * uniquePets.length)].$toDatabaseJson().species;
@@ -85,7 +78,7 @@ class CustomersController {
       // return updated customer
       return res.status(200).json({
         message: `Customer with id ${customerId} has been updated with a gift.`,
-        appliedGift: customer.$toDatabaseJson().gift,
+        appliedGift: customerObj.gift,
         ok: true
       });
 

--- a/src/controller/CustomersController.ts
+++ b/src/controller/CustomersController.ts
@@ -38,10 +38,9 @@ class CustomersController {
         });
 
       }
-      // intermediate arrange
+      // intermediate arrange for customer object prep
       const customerObj = customer?.$toDatabaseJson();
 
-      console.log(customerObj);
       // check if customer has an applied gift.
       if (customerObj.gift) {
         return res.status(200).json({
@@ -50,10 +49,16 @@ class CustomersController {
         });
       }
 
+      // intermediate arrange for date filter prep
+      let d = new Date();
+      d.setMonth(d.getMonth() - 6);
+      const dateFilter = d.toISOString();
+      console.log(dateFilter);
+
       // check if customer is eligible for a gift.
-      const allPurchases = await this._purchasesService.findByCustomerId(customerId);
+      const allPurchases = await this._purchasesService.findByCustomerIdAndDate(customerId, dateFilter);
       const eligiblePurchases = allPurchases.filter((purchase: any) => {
-        return new Date().getTime() - new Date(purchase.$toDatabaseJson().date).getTime() >= 1000 * 60 * 60 * 24 * 30;
+        return new Date().getTime() - new Date(purchase.date).getTime() >= 1000 * 60 * 60 * 24 * 30;
       });
       if (eligiblePurchases.length == 0) {
         return res.status(200).json({
@@ -63,11 +68,11 @@ class CustomersController {
       }
 
       // retrieve all pets of customer
-      // todo: optimize on db level
+      // todo: optimize in db level
       const pets = await this._petsService.findByOwnerId(customerId);
 
       // filter unique pet types
-      // todo: optimize on db level
+      // todo: optimize in db level
       const set = new Set(pets);
       const uniquePets = Array.from(set);
 

--- a/src/controller/CustomersController.ts
+++ b/src/controller/CustomersController.ts
@@ -35,6 +35,7 @@ class CustomersController {
       const regexExp = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
       if (!regexExp.test(customerId)) {
         return res.status(400).json({ 
+          code: 1,
           message: `Customer with id ${customerId} does not exist.`,
           ok: true
          });
@@ -44,6 +45,7 @@ class CustomersController {
       let customer : Customer | undefined = await this._service.findById(customerId);
       if (!customer) {
         return res.status(400).json({
+          code: 2,
           message: `Customer with id ${customerId} does not exist.`,
           ok: true
         });
@@ -55,6 +57,7 @@ class CustomersController {
       // check if customer has an applied gift.
       if (customerObj.gift) {
         return res.status(400).json({
+          code: 3,
           message: `Customer with id ${customerId} already has a gift applied.`,
           ok: true
         });
@@ -67,11 +70,9 @@ class CustomersController {
 
       // check if customer is eligible for a gift.
       const eligiblePurchases : Array<Purchase> | undefined = await this._purchasesService.findByCustomerIdAndDate(customerId, dateFilter);
-      // const eligiblePurchases = allPurchases.filter((purchase: any) => {
-      //   return new Date().getTime() - new Date(purchase.date).getTime() >= 1000 * 60 * 60 * 24 * 30;
-      // });
       if (eligiblePurchases.length == 0) {
         return res.status(400).json({
+          code: 4,
           message: `Customer with id ${customerId} is not eligible for a gift.`,
           ok: true
         });
@@ -79,7 +80,6 @@ class CustomersController {
 
       // retrieve all pets of customer
       const uniquePets : Array<Pet> | undefined  = await this._petsService.findDistinctTypesByOwnerId(customerId);
-      console.log(uniquePets);
 
       // deduce a random pet gift for customer
       const randomSpecies : string = uniquePets[Math.floor(Math.random() * uniquePets.length)].$toDatabaseJson().species;
@@ -89,6 +89,7 @@ class CustomersController {
 
       // return updated customer
       return res.status(200).json({
+        code: 0,
         message: `Customer with id ${customerId} has been updated with a gift.`,
         appliedGift: randomSpecies,
         ok: true

--- a/src/controller/CustomersController.ts
+++ b/src/controller/CustomersController.ts
@@ -4,17 +4,84 @@ import Service from "../service/customers/CustomersService";
 import PetsService from "../service/pets/PetsService";
 import PurchasesService from "../service/purchases/PurchasesService";
 import ApiError from "../middleware/ApiError";
+import Purchase from "../model/Purchase";
 
 @injectable()
 class CustomersController {
-  constructor(private readonly _service: Service, private readonly _petsService: PetsService, private readonly _purchasesService: PurchasesService) {
+  constructor(private readonly _service: Service, private readonly _petsService: PetsService, 
+    private readonly _purchasesService: PurchasesService) {
     this.getAll = this.getAll.bind(this);
+    this.applyGift = this.applyGift.bind(this);
   }
 
   async getAll(req: Request, res: Response, next: NextFunction) {
     try {
       const result = await this._service.getAll();
       return res.status(200).json(result);
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : JSON.stringify(e);
+      next(ApiError.internal(message));
+    }
+  }
+
+  async applyGift(req: Request, res: Response, next: NextFunction) {
+    try {
+      // arrange
+      const { customerId } = req.params;
+
+      // check if customer exists.
+      let customer = await this._service.findById(customerId);
+      if (!customer) {
+        return res.status(200).json({
+          message: `Customer with id ${customerId} does not exist.`,
+          ok: true
+        });
+
+      }
+      // intermediate arrange
+      const customerObj = customer?.$toDatabaseJson();
+
+      console.log(customerObj);
+      // check if customer has an applied gift.
+      if (customerObj.gift) {
+        return res.status(200).json({
+          message: `Customer with id ${customerId} already has a gift applied.`,
+          ok: true
+        });
+      }
+
+      // check if customer is eligible for a gift.
+      const allPurchases = await this._purchasesService.findByCustomerId(customerId);
+      const eligiblePurchases = allPurchases.filter((purchase: any) => {
+        return new Date().getTime() - new Date(purchase.$toDatabaseJson().date).getTime() >= 1000 * 60 * 60 * 24 * 30;
+      });
+      if (eligiblePurchases.length == 0) {
+        return res.status(200).json({
+          message: `Customer with id ${customerId} is not eligible for a gift.`,
+          ok: true
+        });
+      }
+
+      // retrieve all pets of customer
+      const pets = await this._petsService.findByOwnerId(customerId);
+
+      // filter unique pet types
+      const set = new Set(pets);
+      const uniquePets = Array.from(set);
+
+      // deduce a random pet gift for customer
+      const randomSpecies = uniquePets[Math.floor(Math.random() * uniquePets.length)].$toDatabaseJson().species;
+
+      // update customer column with gift
+      customer = await this._service.patchAndFetchById(customerId, { gift: randomSpecies });
+
+      // return updated customer
+      return res.status(200).json({
+        message: `Customer with id ${customerId} has been updated with a gift.`,
+        appliedGift: customer.$toDatabaseJson().gift,
+        ok: true
+      });
+
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : JSON.stringify(e);
       next(ApiError.internal(message));

--- a/src/controller/CustomersController.ts
+++ b/src/controller/CustomersController.ts
@@ -5,6 +5,8 @@ import PetsService from "../service/pets/PetsService";
 import PurchasesService from "../service/purchases/PurchasesService";
 import ApiError from "../middleware/ApiError";
 import Purchase from "../model/Purchase";
+import Customer from "../model/Customer";
+import Pet from "../model/Pet";
 
 @injectable()
 class CustomersController {
@@ -27,12 +29,21 @@ class CustomersController {
   async applyGift(req: Request, res: Response, next: NextFunction) {
     try {
       // arrange
-      const { customerId } = req.params;
+      const { customerId = "<no id provided>" } = req.params;
+
+      // check regex
+      const regexExp = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+      if (!regexExp.test(customerId)) {
+        return res.status(400).json({ 
+          message: `Customer with id ${customerId} does not exist.`,
+          ok: true
+         });
+      }
 
       // check if customer exists.
-      let customer = await this._service.findById(customerId);
+      let customer : Customer | undefined = await this._service.findById(customerId);
       if (!customer) {
-        return res.status(200).json({
+        return res.status(400).json({
           message: `Customer with id ${customerId} does not exist.`,
           ok: true
         });
@@ -43,7 +54,7 @@ class CustomersController {
 
       // check if customer has an applied gift.
       if (customerObj.gift) {
-        return res.status(200).json({
+        return res.status(400).json({
           message: `Customer with id ${customerId} already has a gift applied.`,
           ok: true
         });
@@ -55,22 +66,23 @@ class CustomersController {
       const dateFilter = d.toISOString(); 
 
       // check if customer is eligible for a gift.
-      const allPurchases = await this._purchasesService.findByCustomerIdAndDate(customerId, dateFilter);
-      const eligiblePurchases = allPurchases.filter((purchase: any) => {
-        return new Date().getTime() - new Date(purchase.date).getTime() >= 1000 * 60 * 60 * 24 * 30;
-      });
+      const eligiblePurchases : Array<Purchase> | undefined = await this._purchasesService.findByCustomerIdAndDate(customerId, dateFilter);
+      // const eligiblePurchases = allPurchases.filter((purchase: any) => {
+      //   return new Date().getTime() - new Date(purchase.date).getTime() >= 1000 * 60 * 60 * 24 * 30;
+      // });
       if (eligiblePurchases.length == 0) {
-        return res.status(200).json({
+        return res.status(400).json({
           message: `Customer with id ${customerId} is not eligible for a gift.`,
           ok: true
         });
       }
 
       // retrieve all pets of customer
-      const uniquePets = await this._petsService.findDistinctTypesByOwnerId(customerId);
+      const uniquePets : Array<Pet> | undefined  = await this._petsService.findDistinctTypesByOwnerId(customerId);
+      console.log(uniquePets);
 
       // deduce a random pet gift for customer
-      const randomSpecies = uniquePets[Math.floor(Math.random() * uniquePets.length)].$toDatabaseJson().species;
+      const randomSpecies : string = uniquePets[Math.floor(Math.random() * uniquePets.length)].$toDatabaseJson().species;
 
       // update customer column with gift
       customer = await this._service.patchAndFetchById(customerId, { gift: randomSpecies });
@@ -78,7 +90,7 @@ class CustomersController {
       // return updated customer
       return res.status(200).json({
         message: `Customer with id ${customerId} has been updated with a gift.`,
-        appliedGift: customerObj.gift,
+        appliedGift: randomSpecies,
         ok: true
       });
 

--- a/src/controller/test/CustomersController.test.ts
+++ b/src/controller/test/CustomersController.test.ts
@@ -5,11 +5,16 @@ import Controller from "../CustomersController";
 import Service from "../../service/customers/CustomersService";
 import ApiError from "../../middleware/ApiError";
 
+import PetsService from "../../service/pets/PetsService";
+import PurchasesService from "../../service/purchases/PurchasesService";
+
 const { expect } = chai;
 const sandbox = sinon.createSandbox();
 
 describe("src :: controller :: CustomersController", () => {
   let service: SinonStubbedInstance<Service>;
+  let petsService: SinonStubbedInstance<PetsService>;
+  let purchasesService: SinonStubbedInstance<PurchasesService>;
   let controller: Controller;
 
   let res: Partial<Response>;
@@ -18,9 +23,12 @@ describe("src :: controller :: CustomersController", () => {
 
   beforeEach(() => {
     service = sandbox.createStubInstance(Service);
+    petsService = sandbox.createStubInstance(PetsService);
+    purchasesService = sandbox.createStubInstance(PurchasesService); 
+    
     service.getAll = sandbox.stub();
 
-    controller = new Controller(service);
+    controller = new Controller(service, petsService, purchasesService);
 
     res = {
       status: sandbox.stub().returnsThis(),

--- a/src/controller/test/CustomersController.test.ts
+++ b/src/controller/test/CustomersController.test.ts
@@ -4,6 +4,7 @@ import { Request, Response, NextFunction } from "express";
 import Controller from "../CustomersController";
 import Service from "../../service/customers/CustomersService";
 import ApiError from "../../middleware/ApiError";
+import { v4 as uuidv4 } from "uuid";
 
 import PetsService from "../../service/pets/PetsService";
 import PurchasesService from "../../service/purchases/PurchasesService";
@@ -66,4 +67,35 @@ describe("src :: controller :: CustomersController", () => {
       });
     });
   });
+
+  describe("# applyGift", () => {
+    context("when there isn't an error", () => {
+      it("calls service.findById()", async () => {
+        // arrange
+        const customerId = uuidv4();
+        req = {
+          params: {
+            customerId
+          },
+        };
+        // act
+        await controller.applyGift(req as Request, res as Response, next);
+        // assert
+        sandbox.assert.calledOnce(service.findById);
+      });
+    });
+
+    context("when there is an error", () => {
+      it("calls next with ApiError.internal", async () => {
+        // arrange
+        service.findById.rejects(new Error("error"));
+        // act
+        await controller.applyGift(req as Request, res as Response, next);
+        // assert
+        sandbox.assert.calledOnce(next);
+        sandbox.assert.calledWith(next, sandbox.match.instanceOf(ApiError));
+      });
+    });
+  });
 });
+

--- a/src/dao/pets/PetsDAO.test.ts
+++ b/src/dao/pets/PetsDAO.test.ts
@@ -1,6 +1,6 @@
 import chai from "chai";
 import sinon, { SinonStub } from "sinon";
-import DAO from "../purchases/PurchasesDAO";
+import DAO from "../pets/PetsDAO";
 import { v4 as uuidv4 } from "uuid";
 
 const { expect } = chai;
@@ -12,10 +12,10 @@ const sandbox = sinon.createSandbox();
 interface Methods {
   query: SinonStub<any, Methods>;
   where: SinonStub<any, Methods>;
-  findByCustomerId: SinonStub<any, Methods>;
+  findPetsByOwnerId: SinonStub<any, Methods>;
 }
 
-describe("src :: dao :: purchases :: PurchasesDAO", () => {
+describe("src :: dao :: pets :: PetsDAO", () => {
   let methods: Methods;
   let dao: DAO;
 
@@ -23,7 +23,7 @@ describe("src :: dao :: purchases :: PurchasesDAO", () => {
     methods = {
       query: sandbox.stub(),
       where: sandbox.stub(),
-      findByCustomerId: sandbox.stub(),
+      findPetsByOwnerId: sandbox.stub(),
     };
 
     dao = new DAO(methods as any);
@@ -32,16 +32,16 @@ describe("src :: dao :: purchases :: PurchasesDAO", () => {
   afterEach(() => {
     sandbox.reset();
   });
-
-  describe("# findByCustomerId", () => {
+  
+  describe("# findPetsByOwnerId", () => {
     it("returns an instance array", async () => {
       // arrange
       const id = uuidv4();
       methods.query.returnsThis();
-      methods.findByCustomerId.returnsThis();
+      methods.findPetsByOwnerId.returnsThis();
       methods.where.resolves([{ customerId: id }]);
       // act
-      const result = await dao.findByCustomerId(id);
+      const result = await dao.findPetsByOwnerId(id);
       // assert
       sandbox.assert.calledOnce(methods.where);
       sandbox.assert.calledOnce(methods.query);

--- a/src/dao/pets/PetsDAO.test.ts
+++ b/src/dao/pets/PetsDAO.test.ts
@@ -12,7 +12,7 @@ const sandbox = sinon.createSandbox();
 interface Methods {
   query: SinonStub<any, Methods>;
   where: SinonStub<any, Methods>;
-  findPetsByOwnerId: SinonStub<any, Methods>;
+  findByOwnerId: SinonStub<any, Methods>;
 }
 
 describe("src :: dao :: pets :: PetsDAO", () => {
@@ -23,7 +23,7 @@ describe("src :: dao :: pets :: PetsDAO", () => {
     methods = {
       query: sandbox.stub(),
       where: sandbox.stub(),
-      findPetsByOwnerId: sandbox.stub(),
+      findByOwnerId: sandbox.stub(),
     };
 
     dao = new DAO(methods as any);
@@ -33,15 +33,15 @@ describe("src :: dao :: pets :: PetsDAO", () => {
     sandbox.reset();
   });
   
-  describe("# findPetsByOwnerId", () => {
+  describe("# findByOwnerId", () => {
     it("returns an instance array", async () => {
       // arrange
       const id = uuidv4();
       methods.query.returnsThis();
-      methods.findPetsByOwnerId.returnsThis();
+      methods.findByOwnerId.returnsThis();
       methods.where.resolves([{ customerId: id }]);
       // act
-      const result = await dao.findPetsByOwnerId(id);
+      const result = await dao.findByOwnerId(id);
       // assert
       sandbox.assert.calledOnce(methods.where);
       sandbox.assert.calledOnce(methods.query);

--- a/src/dao/pets/PetsDAO.test.ts
+++ b/src/dao/pets/PetsDAO.test.ts
@@ -12,7 +12,8 @@ const sandbox = sinon.createSandbox();
 interface Methods {
   query: SinonStub<any, Methods>;
   where: SinonStub<any, Methods>;
-  findByOwnerId: SinonStub<any, Methods>;
+  distinct: SinonStub<any, Methods>;
+  findDistinctTypesByOwnerId: SinonStub<any, Methods>;
 }
 
 describe("src :: dao :: pets :: PetsDAO", () => {
@@ -23,7 +24,8 @@ describe("src :: dao :: pets :: PetsDAO", () => {
     methods = {
       query: sandbox.stub(),
       where: sandbox.stub(),
-      findByOwnerId: sandbox.stub(),
+      distinct: sandbox.stub(),
+      findDistinctTypesByOwnerId: sandbox.stub(),
     };
 
     dao = new DAO(methods as any);
@@ -33,15 +35,16 @@ describe("src :: dao :: pets :: PetsDAO", () => {
     sandbox.reset();
   });
   
-  describe("# findByOwnerId", () => {
+  describe("# findDistinctTypesByOwnerId", () => {
     it("returns an instance array", async () => {
       // arrange
       const id = uuidv4();
       methods.query.returnsThis();
-      methods.findByOwnerId.returnsThis();
+      methods.findDistinctTypesByOwnerId.returnsThis();
+      methods.distinct.returnsThis();
       methods.where.resolves([{ customerId: id }]);
       // act
-      const result = await dao.findByOwnerId(id);
+      const result = await dao.findDistinctTypesByOwnerId(id);
       // assert
       sandbox.assert.calledOnce(methods.where);
       sandbox.assert.calledOnce(methods.query);

--- a/src/dao/pets/PetsDAO.ts
+++ b/src/dao/pets/PetsDAO.ts
@@ -13,8 +13,8 @@ class PetDAO extends DAO<Pet> {
     super(_pet);
   }
 
-  async findByOwnerId(id: string) {
-    return this.model.query().where("owner_id", id) as QueryBuilder<Pet>;
+  async findDistinctTypesByOwnerId(id: string) {
+    return this.model.query().distinct("species").where("pets.ownerId", id);
   }
 }
 

--- a/src/dao/pets/PetsDAO.ts
+++ b/src/dao/pets/PetsDAO.ts
@@ -13,7 +13,7 @@ class PetDAO extends DAO<Pet> {
     super(_pet);
   }
 
-  async findPetsByOwnerId(id: string) {
+  async findByOwnerId(id: string) {
     return this.model.query().where("owner_id", id) as QueryBuilder<Pet>;
   }
 }

--- a/src/dao/pets/PetsDAO.ts
+++ b/src/dao/pets/PetsDAO.ts
@@ -1,6 +1,8 @@
 import { inject, injectable } from "inversify";
 import Pet from "../../model/Pet";
 import DAO from "../base-classes/DAO";
+import{ QueryBuilder } from "objection";
+
 
 @injectable()
 class PetDAO extends DAO<Pet> {
@@ -9,6 +11,10 @@ class PetDAO extends DAO<Pet> {
     protected readonly _pet: typeof Pet
   ) {
     super(_pet);
+  }
+
+  async findPetsByOwnerId(id: string) {
+    return this.model.query().where("owner_id", id) as QueryBuilder<Pet>;
   }
 }
 

--- a/src/dao/purchases/PurchasesDAO.test.ts
+++ b/src/dao/purchases/PurchasesDAO.test.ts
@@ -12,7 +12,7 @@ const sandbox = sinon.createSandbox();
 interface Methods {
   query: SinonStub<any, Methods>;
   where: SinonStub<any, Methods>;
-  findByCustomerId: SinonStub<any, Methods>;
+  findByCustomerIdAndDate: SinonStub<any, Methods>;
 }
 
 describe("src :: dao :: purchases :: PurchasesDAO", () => {
@@ -23,7 +23,7 @@ describe("src :: dao :: purchases :: PurchasesDAO", () => {
     methods = {
       query: sandbox.stub(),
       where: sandbox.stub(),
-      findByCustomerId: sandbox.stub(),
+      findByCustomerIdAndDate: sandbox.stub(),
     };
 
     dao = new DAO(methods as any);
@@ -33,17 +33,21 @@ describe("src :: dao :: purchases :: PurchasesDAO", () => {
     sandbox.reset();
   });
 
-  describe("# findByCustomerId", () => {
+  describe("# findByCustomerIdAndDate", () => {
     it("returns an instance array", async () => {
       // arrange
       const id = uuidv4();
+      const dateFilter = new Date().toDateString();
+
       methods.query.returnsThis();
-      methods.findByCustomerId.returnsThis();
-      methods.where.resolves([{ customerId: id }]);
+      methods.findByCustomerIdAndDate.returnsThis();
+      methods.where.onFirstCall().returnsThis();
+      methods.where.onSecondCall().resolves([{ customerId: id }]);
       // act
-      const result = await dao.findByCustomerId(id);
+      const result = await dao.findByCustomerIdAndDate(id, dateFilter);
+      console.log(result);
       // assert
-      sandbox.assert.calledOnce(methods.where);
+      sandbox.assert.calledTwice(methods.where);
       sandbox.assert.calledOnce(methods.query);
       expect(Array.isArray(result)).to.equal(true);
     });

--- a/src/dao/purchases/PurchasesDAO.test.ts
+++ b/src/dao/purchases/PurchasesDAO.test.ts
@@ -45,7 +45,6 @@ describe("src :: dao :: purchases :: PurchasesDAO", () => {
       methods.where.onSecondCall().resolves([{ customerId: id }]);
       // act
       const result = await dao.findByCustomerIdAndDate(id, dateFilter);
-      console.log(result);
       // assert
       sandbox.assert.calledTwice(methods.where);
       sandbox.assert.calledOnce(methods.query);

--- a/src/dao/purchases/PurchasesDAO.test.ts
+++ b/src/dao/purchases/PurchasesDAO.test.ts
@@ -12,6 +12,7 @@ const sandbox = sinon.createSandbox();
 interface Methods {
   query: SinonStub<any, Methods>;
   where: SinonStub<any, Methods>;
+  select: SinonStub<any, Methods>;
   findByCustomerIdAndDate: SinonStub<any, Methods>;
 }
 
@@ -23,6 +24,7 @@ describe("src :: dao :: purchases :: PurchasesDAO", () => {
     methods = {
       query: sandbox.stub(),
       where: sandbox.stub(),
+      select: sandbox.stub(),
       findByCustomerIdAndDate: sandbox.stub(),
     };
 
@@ -39,8 +41,9 @@ describe("src :: dao :: purchases :: PurchasesDAO", () => {
       const id = uuidv4();
       const dateFilter = new Date().toDateString();
 
-      methods.query.returnsThis();
       methods.findByCustomerIdAndDate.returnsThis();
+      methods.query.returnsThis();
+      methods.select.returnsThis();
       methods.where.onFirstCall().returnsThis();
       methods.where.onSecondCall().resolves([{ customerId: id }]);
       // act

--- a/src/dao/purchases/PurchasesDAO.test.ts
+++ b/src/dao/purchases/PurchasesDAO.test.ts
@@ -1,0 +1,52 @@
+import chai from "chai";
+import sinon, { SinonStub } from "sinon";
+import DAO from "../purchases/PurchasesDAO";
+import { Model, PartialModelObject } from "objection";
+import { v4 as uuidv4 } from "uuid";
+
+const { expect } = chai;
+const sandbox = sinon.createSandbox();
+
+// creating an interface is not ideal, but it's necessary due to 
+// limitations with stubbing the Objection.Model instance passed to the DAO
+// for a better test implementation, see Service.test.ts
+interface Methods {
+  query: SinonStub<any, Methods>;
+  where: SinonStub<any, Methods>;
+  findByCustomerId: SinonStub<any, Methods>;
+}
+
+describe("src :: dao :: base-classes :: DAO", () => {
+  let methods: Methods;
+  let dao: DAO;
+
+  beforeEach(() => {
+    methods = {
+      query: sandbox.stub(),
+      where: sandbox.stub(),
+      findByCustomerId: sandbox.stub(),
+    };
+
+    dao = new DAO(methods as any);
+  });
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+  
+  describe("# findByCustomerId", () => {
+    it("returns an instance array", async () => {
+      // arrange
+      const id = uuidv4();
+      methods.query.returnsThis();
+      methods.findByCustomerId.returnsThis();
+      methods.where.resolves([{ customerId: id }]);
+      // act
+      const result = await dao.findByCustomerId(id);
+      // assert
+      sandbox.assert.calledOnce(methods.where);
+      sandbox.assert.calledOnce(methods.query);
+      expect(Array.isArray(result)).to.equal(true);
+    });
+  });
+});

--- a/src/dao/purchases/PurchasesDAO.ts
+++ b/src/dao/purchases/PurchasesDAO.ts
@@ -1,0 +1,15 @@
+import { inject, injectable } from "inversify";
+import Purchase from "../../model/Purchase";
+import DAO from "../base-classes/DAO";
+
+@injectable()
+class PurchaseDAO extends DAO<Purchase> {
+  constructor(
+    @inject("Purchase")
+    protected readonly _purchase: typeof Purchase
+  ) {
+    super(_purchase);
+  }
+}
+
+export default PurchaseDAO;

--- a/src/dao/purchases/PurchasesDAO.ts
+++ b/src/dao/purchases/PurchasesDAO.ts
@@ -13,7 +13,7 @@ class PurchaseDAO extends DAO<Purchase> {
   }
 
   async findByCustomerIdAndDate(id: string, date: string) {
-    return this.model.query().where("customer_id", id).where("date", "<", date) as QueryBuilder<Purchase>;
+    return this.model.query().select('id').where("customer_id", id).where("date", "<", date) as QueryBuilder<Purchase>;
   }
 }
 

--- a/src/dao/purchases/PurchasesDAO.ts
+++ b/src/dao/purchases/PurchasesDAO.ts
@@ -12,8 +12,8 @@ class PurchaseDAO extends DAO<Purchase> {
     super(_purchase);
   }
 
-  async findByCustomerId(id: string) {
-    return this.model.query().where("customer_id", id) as QueryBuilder<Purchase>;
+  async findByCustomerIdAndDate(id: string, date: string) {
+    return this.model.query().where("customer_id", id).where("date", "<", date) as QueryBuilder<Purchase>;
   }
 }
 

--- a/src/dao/purchases/PurchasesDAO.ts
+++ b/src/dao/purchases/PurchasesDAO.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from "inversify";
 import Purchase from "../../model/Purchase";
 import DAO from "../base-classes/DAO";
+import{ QueryBuilder } from "objection";
 
 @injectable()
 class PurchaseDAO extends DAO<Purchase> {
@@ -9,6 +10,10 @@ class PurchaseDAO extends DAO<Purchase> {
     protected readonly _purchase: typeof Purchase
   ) {
     super(_purchase);
+  }
+
+  async findByCustomerId(id: string) {
+    return this.model.query().where("customer_id", id) as QueryBuilder<Purchase>;
   }
 }
 

--- a/src/db/knexFile.ts
+++ b/src/db/knexFile.ts
@@ -12,6 +12,8 @@ const knexFile = {
     port: config.db.port,
     password: config.db.password,
     database: config.db.name,
+    timezone: 'UTC' // https://github.com/Vincit/objection.js/issues/434
+
   },
   pool: {
     min: 0,

--- a/src/db/migrations/20221021022437_add_gifts_column_to_customers_table.ts
+++ b/src/db/migrations/20221021022437_add_gifts_column_to_customers_table.ts
@@ -1,0 +1,12 @@
+import { Knex } from "knex";
+
+export const up = (knex: Knex) => {
+  return knex.schema.alterTable("customers", (table) => {
+    table.string("gifts");
+  });
+};
+
+export const down = (knex: Knex) =>
+  knex.schema.alterTable("customers", (table) => {
+    table.dropColumn("gifts");
+  });

--- a/src/db/migrations/20221021022437_add_gifts_column_to_customers_table.ts
+++ b/src/db/migrations/20221021022437_add_gifts_column_to_customers_table.ts
@@ -2,11 +2,11 @@ import { Knex } from "knex";
 
 export const up = (knex: Knex) => {
   return knex.schema.alterTable("customers", (table) => {
-    table.string("gifts");
+    table.string("gift");
   });
 };
 
 export const down = (knex: Knex) =>
   knex.schema.alterTable("customers", (table) => {
-    table.dropColumn("gifts");
+    table.dropColumn("gift");
   });

--- a/src/db/seeds/seed.ts
+++ b/src/db/seeds/seed.ts
@@ -42,7 +42,7 @@ export const seed = async (knex: Knex) => {
     purchases.push({
       id: uuidv4(),
       customerId: faker.helpers.arrayElement(customers).id,
-      date: faker.date.past(),
+      date: faker.date.past(), // 2021-12-03T05:40:44.408Z format
       total: faker.commerce.price(),
     });
   }

--- a/src/inversify.config.ts
+++ b/src/inversify.config.ts
@@ -3,6 +3,7 @@ import { Container } from "inversify";
 // injections
 import Customer from "./model/Customer";
 import Pet from "./model/Pet";
+import Purchase from "./model/Purchase";
 
 import setupDb from "./db/db-setup";
 setupDb();
@@ -14,5 +15,6 @@ const container = new Container({
 
 container.bind("Customer").toConstantValue(Customer);
 container.bind("Pet").toConstantValue(Pet);
+container.bind("Purchase").toConstantValue(Purchase);
 
 export { container };

--- a/src/model/Customer.ts
+++ b/src/model/Customer.ts
@@ -23,6 +23,7 @@ class Customer extends Model {
         firstName: { type: "string", minLength: 1, maxLength: 255 },
         lastName: { type: "string", minLength: 1, maxLength: 255 },
         email: { type: "string" },
+        gift: { type: "string" }
       },
     };
   }

--- a/src/routes/customersRouter.ts
+++ b/src/routes/customersRouter.ts
@@ -8,4 +8,6 @@ const customersRouter = express.Router();
 
 customersRouter.get("/", controller.getAll);
 
+customersRouter.patch("/gift/:customerId", controller.applyGift);
+
 export default customersRouter;

--- a/src/service/pets/PetsService.test.ts
+++ b/src/service/pets/PetsService.test.ts
@@ -24,7 +24,7 @@ describe("src :: service :: pets :: PetsService", () => {
     dao.truncate = sandbox.stub();
     dao.deleteById = sandbox.stub();
     dao.patchAndFetchById = sandbox.stub();
-    dao.findByOwnerId = sandbox.stub();
+    dao.findDistinctTypesByOwnerId = sandbox.stub();
 
     service = new Service(dao);
   });
@@ -33,15 +33,15 @@ describe("src :: service :: pets :: PetsService", () => {
     sandbox.restore();
     sandbox.reset();
   });
-  describe("# findByOwnerId", () => {
+  describe("# findDistinctTypesByOwnerId", () => {
     it("calls DAOs query method", async () => {
       // arrange
       const id = uuidv4();
-      dao.findByOwnerId.resolves([]);
+      dao.findDistinctTypesByOwnerId.resolves([]);
       // act
-      const result = await service.findByOwnerId(id);
+      const result = await service.findDistinctTypesByOwnerId(id);
       // assert
-      sandbox.assert.calledOnce(dao.findByOwnerId);
+      sandbox.assert.calledOnce(dao.findDistinctTypesByOwnerId);
       expect(result).to.deep.equal([]);
     });
   });

--- a/src/service/pets/PetsService.test.ts
+++ b/src/service/pets/PetsService.test.ts
@@ -1,0 +1,49 @@
+import chai from "chai";
+import sinon, { SinonStubbedInstance } from "sinon";
+import DAO from "../../dao/pets/PetsDAO";
+import { v4 as uuidv4 } from 'uuid';
+
+// file under test
+import Service from "./PetsService";
+import PetDAO from "../../dao/pets/PetsDAO";
+
+const { expect } = chai;
+const sandbox = sinon.createSandbox();
+
+describe("src :: service :: pets :: PetsService", () => {
+  // test double variables (stubs))
+  let dao: SinonStubbedInstance<PetDAO>;
+
+  let service: Service;
+  beforeEach(() => {
+    dao = sandbox.createStubInstance(DAO);
+    dao.getAll = sandbox.stub();
+    dao.insert = sandbox.stub();
+    dao.insertGraph = sandbox.stub();
+    dao.findById = sandbox.stub();
+    dao.truncate = sandbox.stub();
+    dao.deleteById = sandbox.stub();
+    dao.patchAndFetchById = sandbox.stub();
+    dao.findPetsByOwnerId = sandbox.stub();
+
+    service = new Service(dao);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    sandbox.reset();
+  });
+  describe("# findPetsByOwnerId", () => {
+    it("calls DAOs query method", async () => {
+      // arrange
+      const id = uuidv4();
+      dao.findPetsByOwnerId.resolves([]);
+      // act
+      const result = await service.findPetsByOwnerId(id);
+      // assert
+      sandbox.assert.calledOnce(dao.findPetsByOwnerId);
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+});

--- a/src/service/pets/PetsService.ts
+++ b/src/service/pets/PetsService.ts
@@ -9,8 +9,8 @@ class PetsService extends Service<Pet> {
     super(_petsDAO);
   }
 
-  async findByOwnerId(id: string) {
-    return this._petsDAO.findByOwnerId(id);
+  async findDistinctTypesByOwnerId(id: string) {
+    return this._petsDAO.findDistinctTypesByOwnerId(id);
   }
 }
 

--- a/src/service/pets/PetsService.ts
+++ b/src/service/pets/PetsService.ts
@@ -8,6 +8,10 @@ class PetsService extends Service<Pet> {
   constructor(protected readonly _petsDAO: PetsDAO) {
     super(_petsDAO);
   }
+
+  async findPetsByOwnerId(id: string) {
+    return this._petsDAO.findPetsByOwnerId(id);
+  }
 }
 
 export default PetsService;

--- a/src/service/pets/PetsService.ts
+++ b/src/service/pets/PetsService.ts
@@ -9,8 +9,8 @@ class PetsService extends Service<Pet> {
     super(_petsDAO);
   }
 
-  async findPetsByOwnerId(id: string) {
-    return this._petsDAO.findPetsByOwnerId(id);
+  async findByOwnerId(id: string) {
+    return this._petsDAO.findByOwnerId(id);
   }
 }
 

--- a/src/service/purchases/PurcasesService.test.ts
+++ b/src/service/purchases/PurcasesService.test.ts
@@ -24,7 +24,7 @@ describe("src :: service :: purchases :: PurchasesService", () => {
     dao.truncate = sandbox.stub();
     dao.deleteById = sandbox.stub();
     dao.patchAndFetchById = sandbox.stub();
-    dao.findByCustomerId = sandbox.stub();
+    dao.findByCustomerIdAndDate = sandbox.stub();
 
     service = new Service(dao);
   });
@@ -34,15 +34,17 @@ describe("src :: service :: purchases :: PurchasesService", () => {
     sandbox.reset();
   });
   
-  describe("# findByCustomerId", () => {
+  describe("# findByCustomerIdAndDate", () => {
     it("calls DAOs query method", async () => {
       // arrange
       const id = uuidv4();
-      dao.findByCustomerId.resolves([]);
+      const dateFilter = new Date().toDateString();
+
+      dao.findByCustomerIdAndDate.resolves([]);
       // act
-      const result = await service.findByCustomerId(id);
+      const result = await service.findByCustomerIdAndDate(id, dateFilter);
       // assert
-      sandbox.assert.calledOnce(dao.findByCustomerId);
+      sandbox.assert.calledOnce(dao.findByCustomerIdAndDate);
       expect(result).to.deep.equal([]);
     });
   });

--- a/src/service/purchases/PurcasesService.test.ts
+++ b/src/service/purchases/PurcasesService.test.ts
@@ -1,18 +1,18 @@
 import chai from "chai";
 import sinon, { SinonStubbedInstance } from "sinon";
-import DAO from "../../dao/pets/PetsDAO";
+import DAO from "../../dao/purchases/PurchasesDAO";
 import { v4 as uuidv4 } from 'uuid';
 
 // file under test
-import Service from "./PetsService";
-import PetsDAO from "../../dao/pets/PetsDAO";
+import Service from "./PurchasesService";
+import PurchasesDAO from "../../dao/purchases/PurchasesDAO";
 
 const { expect } = chai;
 const sandbox = sinon.createSandbox();
 
-describe("src :: service :: pets :: PetsService", () => {
+describe("src :: service :: purchases :: PurchasesService", () => {
   // test double variables (stubs))
-  let dao: SinonStubbedInstance<PetsDAO>;
+  let dao: SinonStubbedInstance<PurchasesDAO>;
 
   let service: Service;
   beforeEach(() => {
@@ -24,7 +24,7 @@ describe("src :: service :: pets :: PetsService", () => {
     dao.truncate = sandbox.stub();
     dao.deleteById = sandbox.stub();
     dao.patchAndFetchById = sandbox.stub();
-    dao.findByOwnerId = sandbox.stub();
+    dao.findByCustomerId = sandbox.stub();
 
     service = new Service(dao);
   });
@@ -33,15 +33,16 @@ describe("src :: service :: pets :: PetsService", () => {
     sandbox.restore();
     sandbox.reset();
   });
-  describe("# findByOwnerId", () => {
+  
+  describe("# findByCustomerId", () => {
     it("calls DAOs query method", async () => {
       // arrange
       const id = uuidv4();
-      dao.findByOwnerId.resolves([]);
+      dao.findByCustomerId.resolves([]);
       // act
-      const result = await service.findByOwnerId(id);
+      const result = await service.findByCustomerId(id);
       // assert
-      sandbox.assert.calledOnce(dao.findByOwnerId);
+      sandbox.assert.calledOnce(dao.findByCustomerId);
       expect(result).to.deep.equal([]);
     });
   });

--- a/src/service/purchases/PurchasesService.ts
+++ b/src/service/purchases/PurchasesService.ts
@@ -1,0 +1,17 @@
+import { injectable } from "inversify";
+import Service from "../base-classes/Service";
+import PurchasesDAO from "../../dao/purchases/PurchasesDAO";
+import Purchase from "../../model/Purchase";
+
+@injectable()
+class PurchasesService extends Service<Purchase> {
+  constructor(protected readonly _purchasesDAO: PurchasesDAO) {
+    super(_purchasesDAO);
+  }
+
+  async findByCustomerId(id: string) {
+    return this._purchasesDAO.findByCustomerId(id);
+  }
+}
+
+export default PurchasesService;

--- a/src/service/purchases/PurchasesService.ts
+++ b/src/service/purchases/PurchasesService.ts
@@ -9,8 +9,8 @@ class PurchasesService extends Service<Purchase> {
     super(_purchasesDAO);
   }
 
-  async findByCustomerId(id: string) {
-    return this._purchasesDAO.findByCustomerId(id);
+  async findByCustomerIdAndDate(id: string, date: string) {
+    return this._purchasesDAO.findByCustomerIdAndDate(id, date);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -192,15 +192,9 @@
   integrity sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==
 
 "@types/node@*":
-<<<<<<< Updated upstream
-  version "18.11.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
-  integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
-=======
   version "18.11.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.0.tgz#f38c7139247a1d619f6cc6f27b072606af7c289d"
   integrity sha512-IOXCvVRToe7e0ny7HpT/X9Rb2RYtElG1a+VshjwT00HxrM2dWBApHQoqsI6WiY7Q03vdf2bCrIGzVrkF/5t10w==
->>>>>>> Stashed changes
 
 "@types/qs@*":
   version "6.9.7"
@@ -842,15 +836,9 @@ is-binary-path@~2.1.0:
     binary-extensions "^2.0.0"
 
 is-core-module@^2.9.0:
-<<<<<<< Updated upstream
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
-=======
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
   integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
->>>>>>> Stashed changes
   dependencies:
     has "^1.0.3"
 


### PR DESCRIPTION
Added the gift support feature. Route is `PATCH /api/customers/gift/:customerId`

- knexfile alteration to add gift column for users.
- Purchases service and DAO created to retrieve data from the purchases table.
- DAO manipulations under pets and purchases DAOs for specific data retrieval use cases.
- Customer controller access expanded into purchases and pets services.
- id validation (currently uuid) with a very basic abstraction mechanism (not by dependency injection).
- Associated tests implemented. Tests are not in depth as there was no seed data for tests. Stubs limited the functionality.

A production.json file was needed to migrate and seed database. It is created locally (as an exact copy of development.json) and added to .gitignore.